### PR TITLE
配置化调整建议

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,5 +23,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.11</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
+
 </project>

--- a/src/main/java/com/BuffAndCast.java
+++ b/src/main/java/com/BuffAndCast.java
@@ -4,11 +4,13 @@ public class BuffAndCast {
     private String id;
     private String name;
     private int price;
+    private String log_type;
 
-    public BuffAndCast(String id, String name, int price) {
+    public BuffAndCast(String id, String name, int price, String log_type) {
         this.id = id;
         this.name = name;
         this.price = price;
+        this.log_type = log_type;
     }
 
     public String getId() {
@@ -33,6 +35,14 @@ public class BuffAndCast {
 
     public void setPrice(int price) {
         this.price = price;
+    }
+
+    public String getLogType() {
+        return log_type;
+    }
+
+    public void setLogType(String log_type) {
+        this.log_type = log_type;
     }
 
     public String getPriceName() {

--- a/src/main/resources/checklist/checklist.json
+++ b/src/main/resources/checklist/checklist.json
@@ -1,0 +1,81 @@
+{
+  "buff": [
+    {
+      "price": 2, 
+      "type": "dps", 
+      "id": "11334", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u5f3a\u6548\u654f\u6377"
+    }, 
+    {
+      "price": 3, 
+      "type": "dps", 
+      "id": "11405", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u5de8\u4eba\u836f\u5242"
+    }, 
+    {
+      "price": 14, 
+      "type": "dps", 
+      "id": "17038", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u51ac\u6cc9\u706b\u9152"
+    }, 
+    {
+      "price": 25, 
+      "type": "dps", 
+      "id": "17538", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u732b\u9f2c\u836f\u5242"
+    }, 
+    {
+      "price": 23, 
+      "type": "dps", 
+      "id": "17539", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u5f3a\u6548\u5965\u6cd5\u836f\u5242"
+    }, 
+    {
+      "price": 9, 
+      "type": "resources", 
+      "id": "17531", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u6062\u590d\u6cd5\u529b"
+    }, 
+    {
+      "price": 17, 
+      "type": "dps", 
+      "id": "26276", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u5f3a\u6548\u706b\u529b"
+    }, 
+    {
+      "price": 48, 
+      "type": "resources", 
+      "id": "27869", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u9ed1\u6697\u7b26\u6587"
+    }, 
+    {
+      "price": 15, 
+      "type": "protection", 
+      "id": "17544", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u9632\u62a4\u51b0\u971c"
+    }, 
+    {
+      "price": 36, 
+      "type": "protection", 
+      "id": "17548", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u9632\u62a4\u6697\u5f71"
+    }, 
+    {
+      "price": 14, 
+      "type": "dps", 
+      "id": "11474", 
+      "log_type": "SPELL_CAST_SUCCESS", 
+      "name": "\u6697\u5f71\u5f3a\u5316"
+    }
+  ]
+}

--- a/src/main/resources/checklist/gen_checklist.py
+++ b/src/main/resources/checklist/gen_checklist.py
@@ -1,0 +1,20 @@
+# -*- coding: UTF8 -*-
+import json
+
+config = {
+     "buff": [
+            {"id": "11334", "name": "强效敏捷", "price": 2, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "11405", "name": "巨人药剂", "price": 3, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17038", "name": "冬泉火酒", "price": 14, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17538", "name": "猫鼬药剂", "price": 25, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17539", "name": "强效奥法药剂", "price": 23, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17531", "name": "恢复法力", "price": 9, "type": "resources", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "26276", "name": "强效火力", "price": 17, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "27869", "name": "黑暗符文", "price": 48, "type": "resources", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17544", "name": "防护冰霜", "price": 15, "type": "protection", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "17548", "name": "防护暗影", "price": 36, "type": "protection", "log_type": "SPELL_CAST_SUCCESS",},
+            {"id": "11474", "name": "暗影强化", "price": 14, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
+    ],
+}
+
+print(json.dumps(config, indent=2))


### PR DESCRIPTION
1. 监控信息清单与代码逻辑分离：将需要提取的日志buff放入配置生成文件gen_checklist.py中，以json格式注册
> cd $path/to/checklist_folder && python gen_checklist.py > checklist.json

2. 兼容其他类型监控，buff，消耗品等

3. 将不同的监控的需要提取的日志关键词配入监控条目，如
{"id": "11334", "name": "强效敏捷", "price": 2, "type": "dps", "log_type": "SPELL_CAST_SUCCESS",},
这一条是与SPELL_CAST_SUCCESS日志匹配

4. 增加可扩展性，type等自定义kv

